### PR TITLE
should reauthenticate on http status code 602..603

### DIFF
--- a/spec/marketo_api/middleware/raise_error_spec.rb
+++ b/spec/marketo_api/middleware/raise_error_spec.rb
@@ -53,22 +53,13 @@ describe MarketoApi::Middleware::RaiseError do
       end
     end
 
-    context 'when status is 400..600 and body is a string' do
+    context 'when status is 400+ and body is a string' do
       let(:body)   { 'An error occured' }
       let(:status) { 404 }
 
       it 'raises an error with a non-existing error code' do
         expect { on_complete }.to raise_error Faraday::Error::ClientError,
                                               "(error code missing): #{body}"
-      end
-    end
-
-    context 'when the status code is 602..603' do
-      let(:status) { 602 }
-
-      it "raises an error" do
-        expect { on_complete }.to raise_error MarketoApi::UnauthorizedError,
-                                              'INVALID_FIELD: error_message'
       end
     end
   end


### PR DESCRIPTION
Relevant passage from http://developers.marketo.com/rest-api/authentication/#using_an_access_token:

> If an expired token is used to authenticate a REST call, the REST call will fail and return a 603 error code.  If the expired token is used in subsequent REST calls, a 602 error code will be returned.  If either of these codes are received, the client should renew the token by calling Identity endpoint.