### PR TITLE
Campaigns Enhancements

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    marketo_api (0.0.7.pre.alpha)
+    marketo_api (0.1.0.pre.alpha)
       faraday (~> 0.12.2)
       faraday_middleware (~> 0.11.0.1)
       hashie (~> 3.5.6)
@@ -39,7 +39,7 @@ GEM
     guard-rubocop (1.3.0)
       guard (~> 2.0)
       rubocop (~> 0.20)
-    hashie (3.5.6)
+    hashie (3.5.7)
     json (2.1.0)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -119,4 +119,4 @@ DEPENDENCIES
   webmock (~> 1.13.0)
 
 BUNDLED WITH
-   1.14.6
+   1.16.0

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    marketo_api (0.1.0.pre.alpha)
+    marketo_api (0.1.1.pre.alpha)
       faraday (~> 0.12.2)
       faraday_middleware (~> 0.11.0.1)
       hashie (~> 3.5.6)

--- a/lib/marketo_api/api/activities.rb
+++ b/lib/marketo_api/api/activities.rb
@@ -28,11 +28,6 @@ module MarketoApi
         api_get("activities/pagingtoken.json?sinceDatetime=#{mod_time}")
       end
 
-      def add_next_page_token(path, token)
-        path = "#{path}&nextPageToken=#{token}" if token
-        path
-      end
-
       def add_activity_type_ids(type_ids)
         ids = format_filter_values(type_ids)
         if ids

--- a/lib/marketo_api/api/base.rb
+++ b/lib/marketo_api/api/base.rb
@@ -46,6 +46,32 @@ module MarketoApi
         end
       end
 
+      # Internal: Converts a hash into a string that can be consumed by
+      # the Marketo API as a query string
+      #
+      # Examples
+      #
+      #   to_query({ source: 'Sales Engage', workspaceName: 'Global' })
+      #   # => 'source=Sales%20Engage&workspaceName=Global'
+      def to_query(options = {})
+        options.to_query.gsub('+', '%20')
+      end
+
+      # Internal: Append a nextPageToken to a url if token is present
+      #
+      # Examples
+      #
+      #   add_next_page_token('activities.json?')
+      #   # => '/rest/v1/leads'
+      def add_next_page_token(path, token)
+        path += "&nextPageToken=#{token}" if token
+        path
+      end
+
+      def paging_token_param(token)
+        token.present? ? { nextPageToken: token } : {}
+      end
+
       def extract_case_insensitive_string_or_symbol_key_from_hash!(hash, key)
         value = hash.delete(key.to_sym)
         value ||= hash.delete(key.to_s)

--- a/lib/marketo_api/api/base.rb
+++ b/lib/marketo_api/api/base.rb
@@ -68,6 +68,12 @@ module MarketoApi
         path
       end
 
+      # Internal: Returns hash for next page token param
+      #
+      # Examples
+      #
+      #   add_next_page_token('123')
+      #   # => { nextPageToken: '123' }
       def paging_token_param(token)
         token.present? ? { nextPageToken: token } : {}
       end

--- a/lib/marketo_api/api/campaigns.rb
+++ b/lib/marketo_api/api/campaigns.rb
@@ -34,7 +34,7 @@ module MarketoApi
       #
       # Example
       #   # Find the specific campaign
-      #   client.campaigns_by_workspace(true)
+      #   client.campaigns_by_workspace('Default')
       #   # => {
       #          "requestId": "cab#15f4b36d1ca"
       #          "success": "true"
@@ -60,10 +60,65 @@ module MarketoApi
       #        "success": true
       #      }
       #
-      def campaigns_by_workspace(is_triggerable, workspace_name = 'Default')
-        triggerable_param = "isTriggerable=#{is_triggerable ? 1 : 0}"
-        workspace_param = "workspaceName=#{workspace_name}"
-        api_get("campaigns.json?#{triggerable_param}&#{workspace_param}")
+      def campaigns_by_workspace(workspace_name = 'Default', options = {})
+        options[:workspaceName] = workspace_name
+        campaigns(options)
+      end
+
+      def campaigns_next_page(next_page_token, options = {})
+        campaigns(options.merge(paging_token_param(next_page_token)))
+      end
+
+      def campaigns(options = {})
+        options_query = to_query(options)
+        api_get("campaigns.json?#{options_query}")
+      end
+
+      # Public: Passes a set of leads to a trigger campaign to run through the campaign's flow.
+      # The designated campaign must have a Campaign is Requested: Web Service API trigger, and
+      # must be active. My tokens local to the campaign's parent program can be overridden for
+      # the run to customize content.
+      #
+      # Required Permissions: Execute Campaign
+      #
+      #
+      # Example
+      #   # Add lead to trigger campaign
+      #   client.trigger_campaign!(3711, {})
+      #   # => {
+      #          "errors": [
+      #            {
+      #              "code": 0,
+      #              "message": "string"
+      #            }
+      #          ],
+      #          "moreResult": false,
+      #          "nextPageToken": "string",
+      #          "requestId": "string",
+      #          "result": [
+      #            {
+      #              "active": false,
+      #              "createdAt": "string",
+      #              "description": "string",
+      #              "id": 0,
+      #              "name": "string",
+      #              "programId": 0,
+      #              "programName": "string",
+      #              "type": "batch",
+      #              "updatedAt": "string",
+      #              "workspaceName": "string"
+      #            }
+      #          ],
+      #          "success": false,
+      #          "warnings": [
+      #            {
+      #              "code": 0,
+      #              "message": "string"
+      #            }
+      #          ]
+      #        }
+      def trigger_campaign!(campaign_id, attrs)
+        api_post("campaigns/#{campaign_id}/trigger.json", attrs)
       end
     end
   end

--- a/lib/marketo_api/version.rb
+++ b/lib/marketo_api/version.rb
@@ -1,3 +1,3 @@
 module MarketoApi
-  VERSION = '0.1.0-alpha'.freeze
+  VERSION = '0.1.1-alpha'.freeze
 end

--- a/spec/marketo_api/api/activities_spec.rb
+++ b/spec/marketo_api/api/activities_spec.rb
@@ -34,12 +34,6 @@ describe MarketoApi::API::Activities do
     end
   end
 
-  describe '#add_next_page_token' do
-    it 'appends nextPageToken to the path' do
-      expect(subject.add_next_page_token('foo', 'bar')).to eql('foo&nextPageToken=bar')
-    end
-  end
-
   describe '#add_activity_type_ids' do
     context 'when type_ids are passed in' do
       it 'appends activityTypeIds' do

--- a/spec/marketo_api/api/campaigns_spec.rb
+++ b/spec/marketo_api/api/campaigns_spec.rb
@@ -1,0 +1,86 @@
+require 'spec_helper'
+
+describe MarketoApi::API::Campaigns do
+  subject { Class.new.extend(MarketoApi::API::Campaigns) }
+
+  describe '#campaign_by_id' do
+    it 'calls the campaigns/1337.json endpoint' do
+      campaign_id = 1337
+
+      expect(subject).to receive(:api_get).with("campaigns/#{campaign_id}.json")
+
+      subject.campaign_by_id(campaign_id)
+    end
+  end
+
+  describe '#campaigns_by_workspace' do
+    it 'calls #campaigns with default workspace' do
+      options = { workspaceName: 'Default' }
+
+      expect(subject).to receive(:campaigns).with(options)
+
+      subject.campaigns_by_workspace
+    end
+
+    it 'calls #campaigns with workspace' do
+      workspace_name = 'foo'
+      options = { bar: 'baz' }
+
+      expect(subject).
+        to receive(:campaigns).
+        with({ workspaceName: workspace_name }.merge(options))
+
+      subject.campaigns_by_workspace(workspace_name, options)
+    end
+  end
+
+  describe '#campaigns_next_page' do
+    it 'calls #campaigns with next page token' do
+      options = { foo: 'bar' }
+      next_page_token = 'baz'
+      next_page_token_param = { nextPage: next_page_token }
+
+      expect(subject).
+        to receive(:paging_token_param).
+        with(next_page_token).
+        and_return(next_page_token_param)
+      expect(subject).
+        to receive(:campaigns).
+        with(options.merge(next_page_token_param))
+
+      subject.campaigns_next_page(next_page_token, options)
+    end
+  end
+
+  describe '#campaigns' do
+    it 'should call campaigns.json with query params' do
+      options = { foo: 'bar' }
+      options_query = 'foo=bar'
+
+      expect(subject).
+        to receive(:to_query).
+        with(options).
+        and_return(options_query)
+      expect(subject).
+        to receive(:api_get).
+        with("campaigns.json?#{options_query}")
+
+      subject.campaigns(options)
+    end
+  end
+
+  describe '#trigger_campaign!' do
+    it 'calls the campaigns/1337.json endpoint' do
+      campaign_id = 1337
+      attrs = { foo: 'bar' }
+
+      expect(subject).to receive(:api_post).with(
+        "campaigns/#{campaign_id}/trigger.json",
+        attrs
+      )
+
+      subject.trigger_campaign!(campaign_id, attrs)
+    end
+  end
+end
+


### PR DESCRIPTION
## What's in here
- Add methods for Campaigns API
- Move #add_next_page_token to Marketo::API::Base
- Add #to_query to convert hashes to Marketo-consumable query params

### Related PRs

- n/a

### Related Stories

- n/a

### Notes

none
